### PR TITLE
fix shop custom context

### DIFF
--- a/src/modules/rpg/shop-custom.ts
+++ b/src/modules/rpg/shop-custom.ts
@@ -1,5 +1,4 @@
 import Message from "@/message";
-import Module from "@/module";
 import serifs from "@/serifs";
 import * as seedrandom from 'seedrandom';
 import getDate from '@/utils/get-date';
@@ -69,7 +68,7 @@ export const shopCustomReply = async (module: rpg, ai: 藍, msg: Message) => {
     return { reaction: 'love' };
 };
 
-export const shopCustomContextHook = (module: Module, ai: 藍, key: any, msg: Message, data: any) => {
+export const shopCustomContextHook = (module: rpg, ai: 藍, key: any, msg: Message, data: any) => {
     if (key.replace('shopCustom:', '') !== msg.userId) return { reaction: 'hmm' };
     const index = parseInt(msg.text);
     const rpgData = initializeData(module, msg);


### PR DESCRIPTION
## 概要
shopCustomContextHook の引数型が Module となっていたため、initializeData や shopCustomReply の呼び出しで型エラーが発生していました。引数を rpg 型に変更し、不要となった Module の import を削除しました。

## テスト結果
- `npm run build` は依存パッケージ不足のため失敗しました
- `npm install` もビルド時に必要なバイナリ取得ができず失敗しました


------
https://chatgpt.com/codex/tasks/task_e_688c2be8bf108326ab00d62b2cf7518a