### PR TITLE
レート減算時の端数切り上げ対応

### DIFF
--- a/src/friend.ts
+++ b/src/friend.ts
@@ -6,6 +6,7 @@ import { User } from '@/misskey/user';
 import { genItem } from '@/vocabulary';
 import { acct } from '@/utils/acct';
 import { checkNgWord } from '@/utils/check-ng-word';
+import { createDefaultKazutoriData } from '@/modules/kazutori/rate';
 
 export type FriendDoc = {
 	userId: string;
@@ -92,8 +93,8 @@ export default class Friend {
 							doc1.doc.love = 0;
 							this.doc.married = doc1.married || this.married;
 							this.doc.perModulesData = this.mergeAndSum(doc1.doc.perModulesData, this.doc.perModulesData);
-							this.doc.kazutoriData = this.mergeAndSum(doc1.doc.kazutoriData, this.doc.kazutoriData);
-							doc1.doc.kazutoriData = { winCount: 0, playCount: 0, rate: 0, inventory: [] };
+                                                        this.doc.kazutoriData = this.mergeAndSum(doc1.doc.kazutoriData, this.doc.kazutoriData);
+                                                        doc1.doc.kazutoriData = createDefaultKazutoriData();
 							this.save();
 							doc1.save();
 						} else {

--- a/src/modules/kazutori/rate.ts
+++ b/src/modules/kazutori/rate.ts
@@ -1,0 +1,83 @@
+export const KAZUTORI_RATING_VERSION = 1;
+
+export type KazutoriDataContainer = {
+        kazutoriData?: {
+                winCount?: number;
+                playCount?: number;
+                rate?: number;
+                inventory?: string[];
+                medal?: number;
+                ratingVersion?: number;
+                [key: string]: any;
+        };
+};
+
+export type EnsuredKazutoriData = {
+        winCount: number;
+        playCount: number;
+        rate: number;
+        inventory: string[];
+        ratingVersion: number;
+        medal?: number;
+        [key: string]: any;
+};
+
+export function createDefaultKazutoriData(): EnsuredKazutoriData {
+        return {
+                winCount: 0,
+                playCount: 0,
+                rate: 1000,
+                inventory: [],
+                ratingVersion: KAZUTORI_RATING_VERSION,
+        };
+}
+
+export function ensureKazutoriData<T extends KazutoriDataContainer>(target: T): {
+        data: EnsuredKazutoriData;
+        updated: boolean;
+} {
+        let updated = false;
+
+        if (target.kazutoriData == null) {
+                target.kazutoriData = createDefaultKazutoriData();
+                updated = true;
+        } else {
+                const data = target.kazutoriData;
+
+                if (data.ratingVersion !== KAZUTORI_RATING_VERSION) {
+                        data.rate = 1000;
+                        data.ratingVersion = KAZUTORI_RATING_VERSION;
+                        updated = true;
+                }
+
+                if (typeof data.rate !== 'number' || Number.isNaN(data.rate)) {
+                        data.rate = 1000;
+                        updated = true;
+                } else if (!Number.isInteger(data.rate)) {
+                        data.rate = Math.round(data.rate);
+                        updated = true;
+                }
+
+                if (typeof data.winCount !== 'number' || Number.isNaN(data.winCount)) {
+                        data.winCount = 0;
+                        updated = true;
+                }
+
+                if (typeof data.playCount !== 'number' || Number.isNaN(data.playCount)) {
+                        data.playCount = 0;
+                        updated = true;
+                }
+
+                if (!Array.isArray(data.inventory)) {
+                        data.inventory = [];
+                        updated = true;
+                }
+        }
+
+        return { data: target.kazutoriData as EnsuredKazutoriData, updated };
+}
+
+export function findRateRank(records: { userId: string; rate: number }[], userId: string): number | undefined {
+        const index = records.findIndex((record) => record.userId === userId);
+        return index >= 0 ? index + 1 : undefined;
+}

--- a/src/serifs.ts
+++ b/src/serifs.ts
@@ -353,7 +353,12 @@ export default {
 
 		finish: 'ゲームの結果発表です！',
 
-		finishWithWinner: (user, name, item, reverse, perfect, winCount, medal) => `${reverse ? "...ありゃ？逆順で集計しちゃいました！\n" : ""}今回は${user}さん${name ? `(${name})` : ""}の${perfect ? "パーフェクト" : ""}勝ちです！${winCount === 5 || winCount % 10 === 0 ? `\nこれが${winCount}回目の勝利みたいです！` : winCount === 1 ? "\nこれが初勝利みたいです！" : ""}おめでとう！\n景品として${item}${medal ? `とトロフィー(${medal}個目)` : ""}をどうぞ！\nまたやりましょう！`,
+                finishWithWinner: (user, name, item, reverse, perfect, winCount, medal, rateInfo?: { beforeRate: number; afterRate: number; beforeRank?: number; afterRank?: number; }) => {
+                        const rateText = rateInfo
+                                ? `\nレート : ${Math.round(rateInfo.beforeRate)} → ${Math.round(rateInfo.afterRate)}\n順位 : ${rateInfo.beforeRank != null ? `${rateInfo.beforeRank}位` : '順位不明'} → ${rateInfo.afterRank != null ? `${rateInfo.afterRank}位` : '順位不明'}`
+                                : '';
+                        return `${reverse ? "...ありゃ？逆順で集計しちゃいました！\n" : ""}今回は${user}さん${name ? `(${name})` : ""}の${perfect ? "パーフェクト" : ""}勝ちです！${winCount === 5 || winCount % 10 === 0 ? `\nこれが${winCount}回目の勝利みたいです！` : winCount === 1 ? "\nこれが初勝利みたいです！" : ""}おめでとう！${rateText}\n景品として${item}${medal ? `とトロフィー(${medal}個目)` : ""}をどうぞ！\nまたやりましょう！`;
+                },
 
 		finishWithNoWinner: item => `今回は全員負けです...\n${item}は私がもらっておきますね...\nまたやりましょう！`,
 


### PR DESCRIPTION
## 概要
- 参加者が失うレートの算出時に端数を切り上げ、整数での減算になるようにしました
- kazutori データのレートが小数になっていた場合は整数へ丸めるようにしました

## 動作確認
- `npm test`（jest が存在せず実行不可）

------
https://chatgpt.com/codex/tasks/task_e_68e07c8d8050832699b3cca89e03f942