### PR TITLE
レート損失率の調整

### DIFF
--- a/src/modules/kazutori/index.ts
+++ b/src/modules/kazutori/index.ts
@@ -685,7 +685,13 @@ export default class extends Module {
                                 const winnerData = ensureKazutoriData(winnerDoc).data;
                                 const beforeRate = winnerData.rate;
                                 const beforeRank = findRateRank(sortedBefore, winnerFriend.userId);
-                                const lossRatio = Math.max(calculatedLimitMinutes * 0.004, 0.02);
+                                const baseLossRatio = calculatedLimitMinutes * 0.004;
+                                const lossRatio = Math.max(
+                                        baseLossRatio <= 0.04
+                                                ? baseLossRatio
+                                                : 0.04 + (calculatedLimitMinutes - 10) * (1 / 12000),
+                                        0.02
+                                );
                                 let totalBonus = 0;
 
                                 for (const vote of game.votes) {


### PR DESCRIPTION
## 概要
- 参加者のレート損失率が4%を超える場合、超過分の増加幅を1分あたり(1/120)%に変更しました

## テスト
- 未実施

------
https://chatgpt.com/codex/tasks/task_e_68e0869471308326be9b7517919ea1c7