### PR TITLE
ステータス表示で未初期化の数取りデータを補正

### DIFF
--- a/src/modules/core/index.ts
+++ b/src/modules/core/index.ts
@@ -598,15 +598,18 @@ export default class extends Module {
 	}
 
 	@autobind
-	private getStatus(msg: Message): boolean {
-		if (!msg.text) return false;
-		if (!msg.text.includes('ステータス') && !msg.includes(["status"])) return false;
+        private getStatus(msg: Message): boolean {
+                if (!msg.text) return false;
+                if (!msg.text.includes('ステータス') && !msg.includes(["status"])) return false;
 
-		const lovep = msg.friend.love || 0;
-		let love = "";
-		let over = Math.floor(lovep / (100 / 7)) - 7;
-		love += lovep >= -29 ? "★" : "☆";
-		love += lovep >= -10 ? "★" : "☆";
+                const { data: kazutoriData, updated: kazutoriUpdated } = ensureKazutoriData(msg.friend.doc);
+                if (kazutoriUpdated) msg.friend.save();
+
+                const lovep = msg.friend.love || 0;
+                let love = "";
+                let over = Math.floor(lovep / (100 / 7)) - 7;
+                love += lovep >= -29 ? "★" : "☆";
+                love += lovep >= -10 ? "★" : "☆";
 		love += lovep >= 0 ? "★" : "☆";
 		love += lovep >= 5 ? "★" : "☆";
 		love += lovep >= 20 ? "★" : "☆";


### PR DESCRIPTION
## 概要
- ステータス取得時に `ensureKazutoriData` を呼び出すようにし、未初期化の数取りデータを補正
- データが更新された場合にフレンド情報を保存する処理を追加

## テスト
- `npm run build` （依存関係未整備により既知のエラーで失敗）

------
https://chatgpt.com/codex/tasks/task_e_68e088a76f6c8326bb152fbe6398e61c