### PR TITLE
TypeScript 4.3互換の型インポート修正

### DIFF
--- a/src/modules/core/index.ts
+++ b/src/modules/core/index.ts
@@ -13,8 +13,8 @@ import {
         ensureKazutoriData,
         findRateRank,
         createDefaultKazutoriData,
-        type EnsuredKazutoriData,
 } from '@/modules/kazutori/rate';
+import type { EnsuredKazutoriData } from '@/modules/kazutori/rate';
 
 const titles = ['さん', 'くん', '君', 'ちゃん', '様', '先生'];
 


### PR DESCRIPTION
## 概要
- `EnsuredKazutoriData` のインポートを型専用構文に変更し、TypeScript 4.3 でも解釈できるようにしました。


------
https://chatgpt.com/codex/tasks/task_e_68e08f5f68448326a2617a9dfbd730d8