### PR TITLE
レート履歴判定の扱いを修正

### DIFF
--- a/src/modules/core/index.ts
+++ b/src/modules/core/index.ts
@@ -13,6 +13,7 @@ import {
         ensureKazutoriData,
         findRateRank,
         createDefaultKazutoriData,
+        hasKazutoriRateHistory,
 } from '@/modules/kazutori/rate';
 import type { EnsuredKazutoriData } from '@/modules/kazutori/rate';
 
@@ -667,7 +668,7 @@ export default class extends Module {
                         if (doc.userId === userId) {
                                 selfData = data;
                         }
-                        if (data.rateChanged) {
+                        if (hasKazutoriRateHistory(data)) {
                                 ranking.push({ userId: doc.userId, rate: data.rate });
                         }
                 }

--- a/src/modules/kazutori/index.ts
+++ b/src/modules/kazutori/index.ts
@@ -8,7 +8,7 @@ import { acct } from '@/utils/acct';
 import { genItem } from '@/vocabulary';
 import config from '@/config';
 import type { FriendDoc } from '@/friend';
-import { ensureKazutoriData, findRateRank } from './rate';
+import { ensureKazutoriData, findRateRank, hasKazutoriRateHistory } from './rate';
 var Decimal = require('break_infinity.js');
 
 type Game = {
@@ -673,7 +673,7 @@ export default class extends Module {
                                 const { data, updated } = ensureKazutoriData(doc);
                                 if (updated) this.ai.friends.update(doc);
                                 friendDocMap.set(doc.userId, doc);
-                                if (data.rateChanged) {
+                                if (hasKazutoriRateHistory(data)) {
                                         rankingBefore.push({ userId: doc.userId, rate: data.rate });
                                 }
                         }
@@ -736,7 +736,7 @@ export default class extends Module {
 
                                 const rankingAfter = friendDocs.map((doc) => {
                                         const ensured = ensureKazutoriData(doc).data;
-                                        return ensured.rateChanged
+                                        return hasKazutoriRateHistory(ensured)
                                                 ? { userId: doc.userId, rate: ensured.rate }
                                                 : null;
                                 }).filter((record): record is { userId: string; rate: number } => record != null);

--- a/src/modules/kazutori/rate.ts
+++ b/src/modules/kazutori/rate.ts
@@ -24,6 +24,10 @@ export type EnsuredKazutoriData = {
         [key: string]: any;
 };
 
+export function hasKazutoriRateHistory(data: { rate: number; rateChanged?: boolean }): boolean {
+        return Boolean(data.rateChanged) || data.rate !== 1000;
+}
+
 export function createDefaultKazutoriData(): EnsuredKazutoriData {
         return {
                 winCount: 0,
@@ -74,12 +78,7 @@ export function ensureKazutoriData<T extends KazutoriDataContainer>(target: T): 
                 }
 
                 if (typeof data.rateChanged !== 'boolean') {
-                        data.rateChanged =
-                                (typeof data.rate === 'number' && data.rate !== 1000) ||
-                                (typeof data.playCount === 'number' && data.playCount > 0) ||
-                                (typeof data.winCount === 'number' && data.winCount > 0)
-                                        ? true
-                                        : false;
+                        data.rateChanged = typeof data.rate === 'number' && data.rate !== 1000;
                         updated = true;
                 }
 


### PR DESCRIPTION
## 概要
- レート履歴を判定するヘルパー関数を追加しました。
- フラグが無いかつ初期レートのプレイヤーだけをランキングから除外するよう集計処理を修正しました。

## テスト
- `npm test` （jest が見つからず失敗）

------
https://chatgpt.com/codex/tasks/task_e_68e0a350c65c832698d5c228bcca0e00