### PR TITLE
カズトリデータの型を拡張

### DIFF
--- a/src/modules/kazutori/rate.ts
+++ b/src/modules/kazutori/rate.ts
@@ -8,7 +8,7 @@ export type KazutoriDataContainer = {
                 inventory?: string[];
                 medal?: number;
                 ratingVersion?: number;
-                rateChanged?: boolean;
+                rateChanged?: boolean | string | number;
                 [key: string]: any;
         };
 };


### PR DESCRIPTION
## 概要
- kazutoriData.rateChanged に過去データ由来の文字列・数値を受け入れられるよう型を拡張

## テスト
- npm run build (依存関係不足により失敗するが、変更内容とは無関係)


------
https://chatgpt.com/codex/tasks/task_e_68e0b48c0fd883269c93dfa4d1096fa3