### PR TITLE
数取り勝利差反転判定の設定追加

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -39,14 +39,16 @@ type Config = {
 	rpgReplyRequired?: boolean;
 	/** RPGの返信の公開範囲 */
 	rpgReplyVisibility?: string;
-	/** RPG（レイド）の返信の公開範囲 */
-	rpgRaidReplyVisibility?: string;
-	/** 
-	 * チャートからの投稿数取得を強制？
-	 * リモートユーザでも必ず正しい値が取得できる場合はTrueに
-	 * */
-	forceRemoteChartPostCount?: boolean;
-	
+        /** RPG（レイド）の返信の公開範囲 */
+        rpgRaidReplyVisibility?: string;
+        /**
+         * チャートからの投稿数取得を強制？
+         * リモートユーザでも必ず正しい値が取得できる場合はTrueに
+         * */
+        forceRemoteChartPostCount?: boolean;
+        /** 数取りで勝利数差による反転判定を有効にする？ */
+        kazutoriWinDiffReverseEnabled?: boolean;
+
 };
 
 const config = require('../config.json');
@@ -65,5 +67,6 @@ if (!config.rpgCoinName) config.rpgCoinName = "もこコイン";
 if (!config.rpgCoinShortName) config.rpgCoinShortName = "コイン";
 if (config.rpgReplyRequired !== false) config.rpgReplyRequired = true;
 if (!config.forceRemoteChartPostCount) config.forceRemoteChartPostCount = false;
+if (config.kazutoriWinDiffReverseEnabled !== true) config.kazutoriWinDiffReverseEnabled = false;
 
 export default config as Config;

--- a/src/modules/kazutori/index.ts
+++ b/src/modules/kazutori/index.ts
@@ -626,12 +626,12 @@ export default class extends Module {
 			reverseWinner = winner;
 		}
 
-		if (!medal) {
-			const winDiff = (Math.min(winner?.winCount ?? 0, 50)) - (Math.min(reverseWinner?.winCount ?? 0, 50));
-			if (!reverse && winner && winDiff > 10 && Math.random() < Math.min((winDiff - 10) * 0.02, 0.7)) {
-				reverse = !reverse;
-			} else if (reverse && reverseWinner && winDiff < -10 && Math.random() < Math.min((winDiff + 10) * -0.02, 0.7)) {
-				reverse = !reverse;
+                if (!medal && config.kazutoriWinDiffReverseEnabled) {
+                        const winDiff = (Math.min(winner?.winCount ?? 0, 50)) - (Math.min(reverseWinner?.winCount ?? 0, 50));
+                        if (!reverse && winner && winDiff > 10 && Math.random() < Math.min((winDiff - 10) * 0.02, 0.7)) {
+                                reverse = !reverse;
+                        } else if (reverse && reverseWinner && winDiff < -10 && Math.random() < Math.min((winDiff + 10) * -0.02, 0.7)) {
+                                reverse = !reverse;
 			}
 		}
 


### PR DESCRIPTION
## 概要
- configに数取りの勝利数差による反転判定を制御する設定項目を追加しました
- 数取りモジュールで新しい設定値を参照し、判定を無効化するようにしました

## テスト
- 未実施


------
https://chatgpt.com/codex/tasks/task_e_68e0b73b8bd883269a03dd101679d1cd