### PR TITLE
未参加時のレート減少倍率を500毎の50%増に修正

### DIFF
--- a/src/modules/kazutori/index.ts
+++ b/src/modules/kazutori/index.ts
@@ -717,7 +717,11 @@ export default class extends Module {
                                         if (participants.has(doc.userId)) continue;
                                         const data = ensureKazutoriData(doc).data;
                                         if (data.rate > 1000) {
-                                                const loss = Math.min(penaltyPoint, data.rate - 1000);
+                                                const rateExcess = data.rate - 1000;
+                                                const increaseSteps = Math.floor(rateExcess / 500);
+                                                const multiplier = 1 + increaseSteps * 0.5;
+                                                const calculatedLoss = penaltyPoint * multiplier;
+                                                const loss = Math.min(Math.ceil(calculatedLoss), rateExcess);
                                                 if (loss > 0) {
                                                         data.rate -= loss;
                                                         data.rateChanged = true;


### PR DESCRIPTION
## 概要
- 未参加プレイヤーの減少量に適用する倍率を500レート毎に50%増加する仕様へ変更

## テスト
- 未実施（jest: not found のため）

------
https://chatgpt.com/codex/tasks/task_e_68e22f8bccbc832695099271607804f8