### PR TITLE
型インポートを型専用のインポートに分離

### DIFF
--- a/src/modules/kazutori/index.ts
+++ b/src/modules/kazutori/index.ts
@@ -8,7 +8,8 @@ import { acct } from '@/utils/acct';
 import { genItem } from '@/vocabulary';
 import config from '@/config';
 import type { FriendDoc } from '@/friend';
-import { ensureKazutoriData, findRateRank, hasKazutoriRateHistory, type EnsuredKazutoriData } from './rate';
+import { ensureKazutoriData, findRateRank, hasKazutoriRateHistory } from './rate';
+import type { EnsuredKazutoriData } from './rate';
 var Decimal = require('break_infinity.js');
 
 type Game = {


### PR DESCRIPTION
## 概要
- kazutoriモジュールでEnsuredKazutoriDataを型専用のインポートに分離し、型チェックエラーを解消

## テスト
- `npm run build` （依存関係不足により失敗）

------
https://chatgpt.com/codex/tasks/task_e_68e23679824c83269bac898391c24823