### PR TITLE
Ensure rendered maze margin is even and at least 2px

### DIFF
--- a/src/modules/maze/render-maze.ts
+++ b/src/modules/maze/render-maze.ts
@@ -22,7 +22,9 @@ function calcRenderMetrics(mazeSize: number) {
 	const targetCellSize = targetRoadWidth * 1.5;
 	const cellSize = Math.max(6, Math.round(targetCellSize / 6) * 6);
 	const mazeAreaSize = mazeSize * cellSize;
-	const margin = Math.max(1, Math.round(mazeAreaSize * (BASE_MARGIN / BASE_MAZE_AREA)));
+	const rawMargin = Math.round(mazeAreaSize * (BASE_MARGIN / BASE_MAZE_AREA));
+	// margin / 2 を使う描画があるため、余白は 2 以上かつ偶数にそろえる
+	const margin = Math.max(2, Math.ceil(rawMargin / 2) * 2);
 	const imageSize = Math.round(mazeAreaSize + (margin * 2));
 
 	return { imageSize, margin, cellSize };


### PR DESCRIPTION
### Motivation
- Ensure the computed `margin` used for rendering is an even number and at least 2 pixels because some drawing uses `margin / 2`, and odd or zero margins could produce fractional or missing drawing areas.

### Description
- Replace the previous `margin` calculation with a `rawMargin` and compute `margin` as `Math.max(2, Math.ceil(rawMargin / 2) * 2)` so the final margin is always even and >= 2, and add a clarifying comment.

### Testing
- Ran the TypeScript build with `npm run build` and the project test suite with `npm test`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd27204eb48326b028377879c79d9f)