### PR TITLE
数取りの開催成立条件を4人以上に統一

### DIFF
--- a/src/modules/kazutori/index.ts
+++ b/src/modules/kazutori/index.ts
@@ -1130,9 +1130,10 @@ export default class extends Module {
 	 */
 	private async handleOnagareIfNeeded(game: Game, item: string): Promise<boolean> {
 		const medal = this.isMedalMatch(game);
+		const hasInsufficientParticipants = game.votes.length < 4;
 
-		/** お流れ条件: 勝利数50未満が1人以下 かつ メダル戦でない */
-		if (game.votes?.filter((x) => x.user.winCount < 50).length <= 1 && !medal) {
+		/** お流れ条件: 参加者4人未満 または (勝利数50未満が1人以下 かつ メダル戦でない) */
+		if (hasInsufficientParticipants || (game.votes?.filter((x) => x.user.winCount < 50).length <= 1 && !medal)) {
 			game.votes.forEach((x) => {
 				const friend = this.ai.lookupFriend(x.user.id);
 				if (friend) {


### PR DESCRIPTION
### Motivation
- 数取りゲームの成立基準を明確にし、通常戦・トロフィー戦問わず参加者が4人未満の試合を無効（お流れ）にするための変更です。 

### Description
- `src/modules/kazutori/index.ts` にて `hasInsufficientParticipants` (`game.votes.length < 4`) を追加し、`handleOnagareIfNeeded` の判定を `hasInsufficientParticipants || (既存条件)` に変更して、参加者3人以下の試合を強制的にお流れにします。  
- 既存の「勝利数50未満が1人以下かつメダル戦でない場合のお流れ」処理は維持され、既存のお流れ処理（`playCount` 巻き戻し、機嫌補正、投稿など）は4人未満時にもそのまま適用されます。  
- 影響として、トロフィー戦判定を満たしていても参加者が3人以下なら成立せず、レート変動・勝利数加算・メダル付与が発生しなくなります。 

### Testing
- `npm run build` を実行しましたが、この環境では多数の型定義/モジュール解決エラーが発生してビルドは失敗しました（TypeScript の型定義や Node モジュールが不足しているため）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdba779b648326b062b8a9a6becdb1)