### PR TITLE
チャート描画の軸スケールと目盛り小数表示を修正

### DIFF
--- a/src/modules/chart/render-chart.ts
+++ b/src/modules/chart/render-chart.ts
@@ -60,24 +60,29 @@ export function renderChart(chart: Chart) {
 
 	const xAxisCount = chart.datasets[0].data.length;
 	const serieses = chart.datasets.length;
+	const totals = Array.from({ length: xAxisCount }, (_, xAxis) => {
+		let total = 0;
+		for (let series = 0; series < serieses; series++) {
+			total += chart.datasets[series].data[xAxis];
+		}
+		return total;
+	});
 
 	let lowerBound = Infinity;
 	let upperBound = -Infinity;
 
-	for (let xAxis = 0; xAxis < xAxisCount; xAxis++) {
-		let v = 0;
-		for (let series = 0; series < serieses; series++) {
-			v += chart.datasets[series].data[xAxis];
-		}
-		if (v > upperBound) upperBound = v;
-		if (v < lowerBound) lowerBound = v;
+	for (const total of totals) {
+		if (total > upperBound) upperBound = total;
+		if (total < lowerBound) lowerBound = total;
 	}
+	lowerBound = Math.min(0, lowerBound);
 
 	// Calculate Y axis scale
 	const yAxisSteps = niceScale(lowerBound, upperBound, yAxisTicks);
 	const yAxisStepsMin = yAxisSteps[0];
 	const yAxisStepsMax = yAxisSteps[yAxisSteps.length - 1];
 	const yAxisRange = yAxisStepsMax - yAxisStepsMin;
+	const yAxisStepSize = yAxisSteps.length > 1 ? yAxisSteps[1] - yAxisSteps[0] : 0;
 
 	// Draw Y axis
 	ctx.lineWidth = yAxisThickness;
@@ -93,47 +98,18 @@ export function renderChart(chart: Chart) {
 
 		ctx.font = '20px CustomFont';
 		ctx.fillStyle = colors.text;
-		ctx.fillText(step.toString(), chartAreaX, chartAreaY + y - 8);
-	}
-
-	const newDatasets: any[] = [];
-
-	for (let series = 0; series < serieses; series++) {
-		newDatasets.push({
-			data: []
-		});
-	}
-
-	for (let xAxis = 0; xAxis < xAxisCount; xAxis++) {
-		for (let series = 0; series < serieses; series++) {
-			newDatasets[series].data.push(chart.datasets[series].data[xAxis] / yAxisRange);
-		}
+		ctx.fillText(formatAxisLabel(step, yAxisStepSize), chartAreaX, chartAreaY + y - 8);
 	}
 
 	const perXAxisWidth = chartAreaWidth / xAxisCount;
-
-	let newUpperBound = -Infinity;
-
-	for (let xAxis = 0; xAxis < xAxisCount; xAxis++) {
-		let v = 0;
-		for (let series = 0; series < serieses; series++) {
-			v += newDatasets[series].data[xAxis];
-		}
-		if (v > newUpperBound) newUpperBound = v;
-	}
+	const yScale = yAxisRange === 0 ? 0 : chartAreaHeight / yAxisRange;
 
 	// Draw X axis
 	ctx.lineWidth = lineWidth;
 	ctx.lineCap = 'round';
 
 	for (let xAxis = 0; xAxis < xAxisCount; xAxis++) {
-		const xAxisPerTypeHeights: number[] = [];
-
-		for (let series = 0; series < serieses; series++) {
-			const v = newDatasets[series].data[xAxis];
-			const vHeight = (v / newUpperBound) * (chartAreaHeight - ((yAxisStepsMax - upperBound) / yAxisStepsMax * chartAreaHeight));
-			xAxisPerTypeHeights.push(vHeight);
-		}
+		const xAxisPerTypeHeights: number[] = chart.datasets.map(({ data }) => data[xAxis] * yScale);
 
 		for (let series = serieses - 1; series >= 0; series--) {
 			ctx.strokeStyle = colors.dataset[series % colors.dataset.length];
@@ -166,6 +142,11 @@ export function renderChart(chart: Chart) {
 // This routine creates the Y axis values for a graph.
 function niceScale(lowerBound: number, upperBound: number, ticks: number): number[] {
 	if (lowerBound === 0 && upperBound === 0) return [0];
+	if (lowerBound === upperBound) {
+		const padding = Math.abs(lowerBound || 1) * 0.1;
+		lowerBound -= padding;
+		upperBound += padding;
+	}
 
 	// Calculate Min amd Max graphical labels and graph
 	// increments.  The number of ticks defaults to
@@ -192,10 +173,7 @@ function niceScale(lowerBound: number, upperBound: number, ticks: number): numbe
 	const tempStep = range / tiks;
 
 	// Calculate pretty step value
-	const mag = Math.floor(Math.log10(tempStep));
-	const magPow = Math.pow(10, mag);
-	const magMsd = (parseInt as any)(tempStep / magPow);
-	const stepSize = magMsd * magPow;
+	const stepSize = niceNum(tempStep);
 
 	// build Y label array.
 	// Lower and upper bounds calculations
@@ -203,8 +181,9 @@ function niceScale(lowerBound: number, upperBound: number, ticks: number): numbe
 	const ub = stepSize * Math.ceil(upperBound / stepSize);
 	// Build array
 	let val = lb;
+	const decimals = decimalPlaces(stepSize);
 	while (1) {
-		steps.push(val);
+		steps.push(roundTo(val, decimals));
 		val += stepSize;
 		if (val > ub) {
 			break;
@@ -212,4 +191,42 @@ function niceScale(lowerBound: number, upperBound: number, ticks: number): numbe
 	}
 
 	return steps;
+}
+
+function niceNum(value: number): number {
+	const exponent = Math.floor(Math.log10(value));
+	const fraction = value / Math.pow(10, exponent);
+
+	let niceFraction;
+	if (fraction <= 1) {
+		niceFraction = 1;
+	} else if (fraction <= 2) {
+		niceFraction = 2;
+	} else if (fraction <= 5) {
+		niceFraction = 5;
+	} else {
+		niceFraction = 10;
+	}
+
+	return niceFraction * Math.pow(10, exponent);
+}
+
+function decimalPlaces(value: number): number {
+	if (!Number.isFinite(value) || value === 0) return 0;
+	const exponent = Math.floor(Math.log10(Math.abs(value)));
+	return Math.max(0, -exponent + 2);
+}
+
+function roundTo(value: number, decimals: number): number {
+	const factor = Math.pow(10, decimals);
+	return Math.round(value * factor) / factor;
+}
+
+function formatAxisLabel(value: number, stepSize: number): string {
+	const decimals = decimalPlaces(stepSize);
+	const rounded = roundTo(value, decimals);
+	if (Number.isInteger(rounded)) {
+		return rounded.toString();
+	}
+	return rounded.toFixed(Math.min(decimals, 6)).replace(/\.0+$/, '').replace(/(\.\d*?)0+$/, '$1');
 }


### PR DESCRIPTION
### Motivation
- 棒グラフの横軸ごとの表示値と描画される線の高さが一致しない問題を修正するための変更です。  
- Y軸ラベルに浮動小数点誤差（例: `181.800000000007`）が表示される問題を解消する目的があります。  

### Description
- `src/modules/chart/render-chart.ts` の値計算を整理し、各 `x` ごとの合計を事前に算出して上下限を決定するようにしました。  
- 既存の二重正規化処理（`newDatasets` / `newUpperBound`）を削除し、Y軸レンジから直接スケール (`yScale`) を算出して系列ごとの高さ計算を行うように変更しました。  
- Y軸の下限を `Math.min(0, lowerBound)` として 0 以下に寄せる補正を追加し、正値中心のデータで不自然なスケーリングにならないようにしました。  
- 目盛り生成ロジック `niceScale` を改善し、`niceNum` / `decimalPlaces` / `roundTo` / `formatAxisLabel` を導入して「1/2/5/10」ベースの見やすいステップ選択とラベルの丸めを行い、浮動小数点誤差をラベルに表示しないようにしました。  

### Testing
- `npm run build` を実行しましたが、開発環境に型定義や依存パッケージが揃っていないためビルドは失敗しました（環境依存の既存エラーが多数発生）。  
- 変更箇所は `src/modules/chart/render-chart.ts` に集約されており、単体の描画動作確認（実際の画像出力による確認）は依存パッケージ（`canvas` 等）がある環境での実行が必要です。  

副作用・注意点:  
- Y軸を 0 基準に寄せるため、全データが高めで横ばいのケースでは変化量が相対的に見えにくくなる可能性があります。  
- `niceScale` のステップ選択が見やすさ優先に変わるため、従来と目盛り刻みや表示値が若干変わる場合があります。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece0e448b48326bac529a638a02b6c)