### PR TITLE
Integer Y-axis labels and fixed tick grid for non-negative charts

### DIFF
--- a/src/modules/chart/render-chart.ts
+++ b/src/modules/chart/render-chart.ts
@@ -78,11 +78,13 @@ export function renderChart(chart: Chart) {
 	lowerBound = Math.min(0, lowerBound);
 
 	// Calculate Y axis scale
-	const yAxisSteps = niceScale(lowerBound, upperBound, yAxisTicks);
+	const yAxisSteps = createYAxisSteps(lowerBound, upperBound, yAxisTicks);
 	const yAxisStepsMin = yAxisSteps[0];
 	const yAxisStepsMax = yAxisSteps[yAxisSteps.length - 1];
 	const yAxisRange = yAxisStepsMax - yAxisStepsMin;
 	const yAxisStepSize = yAxisSteps.length > 1 ? yAxisSteps[1] - yAxisSteps[0] : 0;
+	const roundedYAxisLabelCount = new Set(yAxisSteps.map((step) => Math.round(step))).size;
+	const shouldRoundYAxisLabelToInteger = roundedYAxisLabelCount === yAxisSteps.length;
 
 	// Draw Y axis
 	ctx.lineWidth = yAxisThickness;
@@ -98,7 +100,11 @@ export function renderChart(chart: Chart) {
 
 		ctx.font = '20px CustomFont';
 		ctx.fillStyle = colors.text;
-		ctx.fillText(formatAxisLabel(step, yAxisStepSize), chartAreaX, chartAreaY + y - 8);
+		ctx.fillText(
+			formatAxisLabel(step, yAxisStepSize, shouldRoundYAxisLabelToInteger),
+			chartAreaX,
+			chartAreaY + y - 8
+		);
 	}
 
 	const perXAxisWidth = chartAreaWidth / xAxisCount;
@@ -193,6 +199,22 @@ function niceScale(lowerBound: number, upperBound: number, ticks: number): numbe
 	return steps;
 }
 
+function createYAxisSteps(lowerBound: number, upperBound: number, ticks: number): number[] {
+	if (upperBound <= 0) {
+		return niceScale(lowerBound, upperBound, ticks);
+	}
+
+	// For note/follower charts, values are non-negative.
+	// Build exactly "ticks" grid lines above zero (plus the zero baseline).
+	if (lowerBound >= 0) {
+		const stepSize = niceNum(upperBound / ticks);
+		const decimals = decimalPlaces(stepSize);
+		return Array.from({ length: ticks + 1 }, (_, i) => roundTo(stepSize * i, decimals));
+	}
+
+	return niceScale(lowerBound, upperBound, ticks);
+}
+
 function niceNum(value: number): number {
 	const exponent = Math.floor(Math.log10(value));
 	const fraction = value / Math.pow(10, exponent);
@@ -222,9 +244,12 @@ function roundTo(value: number, decimals: number): number {
 	return Math.round(value * factor) / factor;
 }
 
-function formatAxisLabel(value: number, stepSize: number): string {
+function formatAxisLabel(value: number, stepSize: number, roundToInteger: boolean): string {
 	const decimals = decimalPlaces(stepSize);
 	const rounded = roundTo(value, decimals);
+	if (roundToInteger) {
+		return Math.round(rounded).toString();
+	}
 	if (Number.isInteger(rounded)) {
 		return rounded.toString();
 	}


### PR DESCRIPTION
### Motivation
- Ensure Y axis labels are integer-friendly for charts with non-negative values (e.g. notes/follower charts) and produce a consistent grid of ticks above the zero baseline.

### Description
- Replace direct use of `niceScale` in `render-chart.ts` with a new helper `createYAxisSteps(lowerBound, upperBound, ticks)` to handle non-negative ranges specially.
- Implement `createYAxisSteps` so that when `lowerBound >= 0` it builds exactly `ticks + 1` grid lines starting at zero using `niceNum(upperBound / ticks)`, otherwise it falls back to `niceScale`.
- Compute `shouldRoundYAxisLabelToInteger` from the generated steps and pass it to the updated `formatAxisLabel(value, stepSize, roundToInteger)` which now returns integer labels when appropriate.
- Keep existing utilities `niceScale`, `niceNum`, `decimalPlaces`, and `roundTo` and adjust label formatting logic to preserve previous behavior for non-integer steps.

### Testing
- Ran the project unit test suite with `npm test` and all tests passed.
- Ran a TypeScript build with `yarn build` to verify compile success and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee9142334483269efc79d51a2396f5)