### PR TITLE
Allow RPG bot mentions without reply

### DIFF
--- a/src/message.ts
+++ b/src/message.ts
@@ -120,6 +120,15 @@ export default class Message {
 	}
 
 	/**
+	 * Bot向けメンションとして扱われた投稿かどうかを取得する
+	 * @returns `isBotMention` 属性が明示的に `true` の場合のみ `true`
+	 * @internal
+	 */
+	public get isBotMention(): boolean {
+		return this.note.isBotMention === true;
+	}
+
+	/**
 	 * メンション部分を除いたテキスト本文を取得する
 	 *
 	 * @remarks

--- a/src/misskey/note.ts
+++ b/src/misskey/note.ts
@@ -34,6 +34,8 @@ export type Note = {
 	visibility: string;
 	/** 投稿者のユーザー情報 */
 	user: any | null;
+	/** Bot向けメンションとして扱われた投稿かどうか */
+	isBotMention?: boolean;
 	/**
 	 * アンケート情報
 	 *

--- a/src/modules/rpg/README.md
+++ b/src/modules/rpg/README.md
@@ -11,7 +11,7 @@ RPGゲーム — メンションによって起動し、ターン制の戦闘・
 flowchart TD
     A["メンション受信"] --> B{"RPG含む?"}
     B -- No --> Z["false（他モジュールへ）"]
-    B -- Yes --> C{"返信必須チェック"}
+    B -- Yes --> C{"返信必須チェック\n(isBotMention=trueは免除)"}
     C -- NG --> Z2["hmm リアクション"]
     C -- OK --> D{"コマンド判定"}
 
@@ -329,7 +329,7 @@ flowchart TD
 | `rpgHeroName` | string | `もこチキ` | 主人公の名前 |
 | `rpgCoinName` | string | `もこコイン` | 通貨の名前 |
 | `rpgCoinShortName` | string | `コイン` | 通貨の短縮名 |
-| `rpgReplyRequired` | boolean | `true` | RPGコマンドを返信必須にする |
+| `rpgReplyRequired` | boolean | `true` | RPGコマンドを返信必須にする（投稿属性 `isBotMention` が `true` の場合は免除） |
 | `rpgReplyVisibility` | string | — | RPGの返信の公開範囲 |
 | `rpgRaidReplyVisibility` | string | — | レイドの返信の公開範囲 |
 

--- a/src/modules/rpg/index.ts
+++ b/src/modules/rpg/index.ts
@@ -185,7 +185,7 @@ export default class extends Module {
 	 */
 	@autobind
 	private async mentionHook(msg: Message) {
-		if (config.rpgReplyRequired && !msg.user.host && msg.visibility !== "specified" && (!msg.replyId || msg.replyNote?.userId !== this.ai.account.id)) {
+		if (config.rpgReplyRequired && !msg.isBotMention && !msg.user.host && msg.visibility !== "specified" && (!msg.replyId || msg.replyNote?.userId !== this.ai.account.id)) {
 			if (msg.includes([serifs.rpg.command.rpg])) {
 				msg.reply("RPG関連のコマンドを使用する際は私の何らかの投稿への返信で送ってください！", { visibility: "specified" })
 				return {

--- a/test/message.spec.ts
+++ b/test/message.spec.ts
@@ -1,0 +1,35 @@
+import Message from '@/message';
+
+const createMessage = (note: Record<string, any>) => {
+	const friends = new Map<string, any>();
+	const ai = {
+		account: { username: 'ai' },
+		api: jest.fn().mockResolvedValue(note.user),
+		friends: {
+			findOne: ({ userId }: { userId: string }) => friends.get(userId) ?? null,
+			insertOne: (doc: any) => {
+				friends.set(doc.userId, doc);
+				return doc;
+			},
+			update: jest.fn(),
+		},
+	};
+
+	return new Message(ai as any, {
+		id: 'note-id',
+		text: '@ai RPG',
+		userId: 'user-id',
+		user: { id: 'user-id', username: 'user', host: null },
+		visibility: 'home',
+		localOnly: false,
+		...note,
+	});
+};
+
+describe('Message#isBotMention', () => {
+	test('isBotMention が true の投稿だけ true を返す', () => {
+		expect(createMessage({ isBotMention: true }).isBotMention).toBe(true);
+		expect(createMessage({ isBotMention: false }).isBotMention).toBe(false);
+		expect(createMessage({}).isBotMention).toBe(false);
+	});
+});


### PR DESCRIPTION
### Motivation
- RPGコマンドのローカルユーザ向けに設定されている「返信必須」制限を、投稿側で明示的にBot向けメンションであることを示す属性がある場合に免除したい。\n
### Description
- `Message` に `isBotMention` のゲッターを追加し、投稿属性 `isBotMention === true` のときのみ `true` を返すようにしました（`src/message.ts`）。
- Misskeyノート型に任意属性 `isBotMention?: boolean` を追加して型を拡張しました（`src/misskey/note.ts`）。
- RPGモジュールのメンションチェックに `!msg.isBotMention` 条件を追加し、`isBotMention` が `true` の投稿では `rpgReplyRequired` による返信必須チェックをスキップするようにしました（`src/modules/rpg/index.ts`）。
- ドキュメントに例外を追記し、`rpgReplyRequired` の説明に `isBotMention` の免除条件を明記しました（`src/modules/rpg/README.md`）。
- `Message#isBotMention` の基本動作を確認するユニットテストを追加しました（`test/message.spec.ts`）。
- 実装上の注意点として、上流（API クライアント等）から誤って `isBotMention: true` が付与されると返信必須チェックを迂回してしまう可能性があります。これにより期待しない投稿が返信必須無しで処理される副作用が発生し得ます。\n
### Testing
- 追加したユニットテスト `test/message.spec.ts` を作成し内容は `Message#isBotMention` の振る舞いを検証するものです（テストソースはコミット済み）。
- 実行したコマンド: `git diff --check --cached`（差分チェックは問題なし）。
- 自動テスト実行: `npm test -- --runInBand test/message.spec.ts` は環境に `jest` がインストールされておらず実行できませんでした（`jest: not found`）。
- ビルド: `npm run build` は依存関係・型定義が未インストールのためフルビルドは失敗しました（多数の外部モジュール型エラー）。
- 依存取得: `npm install` を試みましたがレジストリから一部パッケージ取得で `403 Forbidden` が発生し失敗しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd8014950832683d4769abd8f41e5)